### PR TITLE
Debug issues found in demo site testing

### DIFF
--- a/quell-client/README.md
+++ b/quell-client/README.md
@@ -64,7 +64,7 @@ Quellify('/graphQL', sampleQuery, costOptions)
   .then( /* use parsed response */ );
 ```
 
-Note: Quell will return a promise that resolves into a JS object containing your data in the same form as a typical GraphQL response `{ data: // response }`
+Note: Quell will return a promise that resolves into an array with two elements. The first element will be a JS object containing your data; this is in the same form as the response found on the 'data' key of a typical GraphQL response `{ data: // response }`. The second element will be a boolean indicating whether or not the data was found in the client-side cache.
 
 That's it! You're now caching your GraphQL queries in the LokiJS client-side cache storage.
 
@@ -77,9 +77,9 @@ That's it! You're now caching your GraphQL queries in the LokiJS client-side cac
 # Future Additions
 Goals for the future of Quell/client include:
   - The caching logic for the server-side is multi-faceted, allowing for each query to be broken down into parts and have each data point cached individually. The client-side logic was not working as intended and was iterating through each data-point in the cache. As the cache grew in size this became extremely slow, and as such, the most recent iteration of quell removes much of the functionality to trim the file size down and prevent this issue. 
-    1) Implement caching algorithims for caching subsequest queries after a mutation (currently cache invalidation resets the cache after a mutation).
+    1) Implement caching algorithms for caching subsequent queries after a mutation (currently cache invalidation resets the cache after a mutation).
     2) Re-write much of the core logic, as LokiDB has significantly different functions and benefits than a Redis DB. Alternatively, as the logic is very simple right now, the DB could be transitioned from LokiDB to a newer DB technology that also offers in-memory storage for quick retrieval of data. 
-  - The previous testing suites created during the original implementation of Quell/client were very thorough, but as the project grew in complexity and versins these tests were not updated to test the new functionality. 
+  - The previous testing suites created during the original implementation of Quell/client were very thorough, but as the project grew in complexity and versions these tests were not updated to test the new functionality. 
     1) Create new testing suites for the current implementation of the client-side cache.
     2) Restart TDD from the ground up while implementing mutation caching logic. 
 

--- a/quell-client/src/Quellify.ts
+++ b/quell-client/src/Quellify.ts
@@ -97,7 +97,7 @@ async function Quellify(
     try {
       const data = await fetch(endPoint, fetchConfig);
       const response = await data.json();
-      return response.queryResponse;
+      return response.queryResponse.data;
     } catch (error) {
       const err: ClientErrorType = {
         log: `Error when trying to perform fetch to graphQL endpoint: ${error}.`,
@@ -182,8 +182,8 @@ async function Quellify(
       // If the query has not been made already, execute a fetch request with the query.
       const parsedData: JSONObject = await performFetch(postFetch);
       // Add the new data to the lokiCache.
-      if (parsedData && parsedData.data) {
-        const addedEntry = lokiCache.insert(parsedData.data);
+      if (parsedData) {
+        const addedEntry = lokiCache.insert(parsedData);
         // Add query $loki ID to IDcache at query key
         IDCache[query] = addedEntry.$loki;
         // The second element in the return array is a boolean that the data was not found in the lokiCache.

--- a/quell-server/src/quell.ts
+++ b/quell-server/src/quell.ts
@@ -1659,10 +1659,10 @@ export class QuellCache {
       if (currentDepth > maxDepth) {
         // Pass error to Express if the maximum depth has been exceeded.
         const err: ServerErrorType = {
-          log: `Depth limit exceeded, tried to send query with the depth of ${currentDepth}.`,
+          log: 'Error in QuellCache.determineDepth: depth limit exceeded.',
           status: 413, // Content Too Large
           message: {
-            err: 'Error in QuellCache.determineDepth. Check server log for more details.'
+            err: `Depth limit exceeded, tried to send query with the depth of ${currentDepth}.`
           }
         };
         res.locals.queryErr = err;
@@ -1751,10 +1751,10 @@ export class QuellCache {
       // Pass error to Express if the maximum cost has been exceeded.
       if (cost > maxCost) {
         const err: ServerErrorType = {
-          log: `Cost limit exceeded, tried to send query with a cost exceeding ${maxCost}.`,
+          log: 'Error in costLimit.determineCost(helper): cost limit exceeded.',
           status: 413, // Content Too Large
           message: {
-            err: 'Error in costLimit.determineCost(helper). Check server log for more details.'
+            err: `Cost limit exceeded, tried to send query with a cost exceeding ${maxCost}.`
           }
         };
         res.locals.queryErr = err;
@@ -1794,10 +1794,10 @@ export class QuellCache {
       // Pass error to Express if the maximum cost has been exceeded.
       if (totalCost > maxCost) {
         const err: ServerErrorType = {
-          log: `Cost limit exceeded, tried to send query with a cost exceeding ${maxCost}.`,
+          log: 'Error in costLimit.determineDepthCost(helper): cost limit exceeded.',
           status: 413, // Content Too Large
           message: {
-            err: 'Error in costLimit.determineDepthCost(helper). Check server log for more details.'
+            err: `Cost limit exceeded, tried to send query with a cost exceeding ${maxCost}.`
           }
         };
         res.locals.queryErr = err;

--- a/quell-server/src/quell.ts
+++ b/quell-server/src/quell.ts
@@ -1582,8 +1582,7 @@ export class QuellCache {
             log: `Error inside catch block of getRedisValues, ${error}`,
             status: 400,
             message: {
-              error:
-                'Error in redis - getRedisValues. Check server log for more details.'
+              err: 'Error in redis - getRedisValues. Check server log for more details.'
             }
           };
           return next(err);


### PR DESCRIPTION
**What is the problem you were trying to solve?**
- The client-side cache function response was not consistent for the different operations, and the current demo site was expecting the return value to include a boolean indicating whether or not the data was found in the cache.
-  The server-side depth limit and cost limit functions' error handlers would benefit from clearer error messages.

**What is your solution and why did you solve this problem the way you did?**
- Modified Quellify.ts to use the 'queryResponse.data' from the fetch response.
- Modified Quellify.ts to return an array with the query data and a boolean indicating whether or not the data was found in the cache.
- Modified quell-client README to reflect changes to the shape of the return value
- Modified depthLimit and costLimit errors to indicate that the cost/depth was exceeded and also say what the limit is.

**Provide any additional notes on testing this functionality:**


**Screenshots / gifs of working solution:**


